### PR TITLE
Add riscv-ai-compiler skeleton

### DIFF
--- a/riscv-ai-compiler/README.md
+++ b/riscv-ai-compiler/README.md
@@ -1,0 +1,5 @@
+# RISCV AI Compiler
+
+This directory contains the source code and tooling for the RISCV AI compiler
+project. It includes example passes, a simple training script, and a placeholder
+Gradio-based UI. All files are currently placeholders.

--- a/riscv-ai-compiler/docker/Dockerfile
+++ b/riscv-ai-compiler/docker/Dockerfile
@@ -1,0 +1,14 @@
+# Base image for riscv-ai-compiler
+FROM ubuntu:22.04
+
+# Install dependencies (placeholder)
+RUN apt-get update && apt-get install -y \
+    build-essential \
+    python3 \
+    python3-pip
+
+WORKDIR /workspace
+
+COPY . /workspace
+
+CMD ["/bin/bash"]

--- a/riscv-ai-compiler/docker/entrypoint
+++ b/riscv-ai-compiler/docker/entrypoint
@@ -1,0 +1,5 @@
+#!/bin/bash
+set -e
+
+# Placeholder entrypoint for riscv-ai-compiler
+exec "$@"

--- a/riscv-ai-compiler/model/train.py
+++ b/riscv-ai-compiler/model/train.py
@@ -1,0 +1,9 @@
+"""Placeholder training script for RISCV AI compiler models."""
+
+
+def main():
+    print("Training script placeholder")
+
+
+if __name__ == "__main__":
+    main()

--- a/riscv-ai-compiler/passes/A2_static_feats.cpp
+++ b/riscv-ai-compiler/passes/A2_static_feats.cpp
@@ -1,0 +1,9 @@
+// Placeholder for pass: A2_static_feats.cpp
+// This file will contain implementation of the static features pass.
+
+#include <iostream>
+
+int main() {
+    std::cout << "A2_static_feats pass placeholder" << std::endl;
+    return 0;
+}

--- a/riscv-ai-compiler/passes/A4_branch_inject.cpp
+++ b/riscv-ai-compiler/passes/A4_branch_inject.cpp
@@ -1,0 +1,9 @@
+// Placeholder for pass: A4_branch_inject.cpp
+// This file will contain implementation of the branch injection pass.
+
+#include <iostream>
+
+int main() {
+    std::cout << "A4_branch_inject pass placeholder" << std::endl;
+    return 0;
+}

--- a/riscv-ai-compiler/ui/gradio_frontend.py
+++ b/riscv-ai-compiler/ui/gradio_frontend.py
@@ -1,0 +1,9 @@
+"""Placeholder Gradio UI for RISCV AI compiler."""
+
+
+def main():
+    print("Gradio UI placeholder")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- scaffold riscv-ai-compiler directory with Docker files
- add placeholder passes, model training script, and UI stub
- include README for riscv-ai-compiler

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68420ff63dcc83259e0f5e8a7d8c4393